### PR TITLE
Fix race condition by removing shared CSV file usage

### DIFF
--- a/nselib/capital_market/get_func.py
+++ b/nselib/capital_market/get_func.py
@@ -11,12 +11,9 @@ def get_price_volume_and_deliverable_position_data(symbol: str, from_date: str, 
     try:
         data_text = nse_urlfetch(url + payload, origin_url=origin_url).text
         data_text = data_text.replace('\x82', '').replace('â¹', 'In Rs')
-        with open('file.csv', 'w') as f:
-            f.write(data_text)
-        f.close()
     except Exception as e:
         raise NSEdataNotFound(f" Resource not available MSG: {e}")
-    data_df = pd.read_csv('file.csv')
+    data_df = pd.read_csv(StringIO(data_text))
     data_df.columns = [name.replace(' ', '') for name in data_df.columns]
     return data_df
 


### PR DESCRIPTION
### Problem
When fetching price_volume_and_deliverable_position_data for multiple symbols in parallel
(e.g. ThreadPoolExecutor), inconsistent CSV parsing errors occur such as:
- No columns to parse from file
- Error tokenizing data
- Empty DataFrames for valid symbols

### Root Cause
The function writes API response data to a fixed filename (`file.csv`)
before reading it back. In parallel execution, multiple calls overwrite
this shared file, causing race conditions.

### Fix
Removed intermediate file I/O and parse CSV data directly from memory
using `StringIO`.

### Benefits
- Thread-safe
- Faster (no disk I/O)
- No behavior change for sequential usage
