### PR TITLE
Fix fetching index data returns only 4-5 months of data

### DIFF
--- a/nselib/capital_market/get_func.py
+++ b/nselib/capital_market/get_func.py
@@ -64,7 +64,7 @@ def get_india_vix_data(from_date: str, to_date: str):
 def get_index_data(index: str, from_date: str, to_date: str):
     index = index.replace(' ', '%20').upper()
     origin_url = "https://www.nseindia.com/reports-indices-historical-index-data"
-    url = f"https://www.nseindia.com/api/historicalOR/indicesHistory?indexType={index}&from={from_date}&to={to_date}"
+    url = f"https://www.nseindia.com/api/historicalOR/indicesHistory?indexType={index}&from={from_date}&to={to_date}&csv=true"
     try:
         data_json = nse_urlfetch(url, origin_url=origin_url).json()
         data_df = pd.DataFrame(data_json['data'])


### PR DESCRIPTION
update get_index_data in get_func.py to use &csv=true, if we do this api gives all data of required duration and not just 4-5 months of data.

Max 1 year of data can be downloaded via this method.