### PR TITLE
use nse's Nifty midcap 150name

### DIFF
--- a/nselib/indices/nse_config.py
+++ b/nselib/indices/nse_config.py
@@ -50,7 +50,7 @@ class NiftySectoralIndices:
 
 class NiftyBroadMarketIndices:
     indices_list = ["Nifty 50", "Nifty Next 50", "Nifty 100", "Nifty 200", "Nifty Total Market", "Nifty 500",
-                    "Nifty Midcap150", "Nifty Midcap 50", "Nifty Midcap Select", "Nifty Midcap 100",
+                    "Nifty Midcap 150", "Nifty Midcap 50", "Nifty Midcap Select", "Nifty Midcap 100",
                     "Nifty Smallcap 250", "Nifty Smallcap 50", "Nifty Smallcap 100", "Nifty Microcap 250",
                     "Nifty LargeMidcap 250", "Nifty MidSmallcap 400", "Nifty India FPI 150", "India Vix"]
     index_constituent_list_urls = {
@@ -60,7 +60,7 @@ class NiftyBroadMarketIndices:
         "Nifty 200": "https://nsearchives.nseindia.com/content/indices/ind_nifty200list.csv",
         "Nifty Total Market": "https://nsearchives.nseindia.com/content/indices/ind_niftytotalmarket_list.csv",
         "Nifty 500": "https://nsearchives.nseindia.com/content/indices/ind_nifty500list.csv",
-        "Nifty Midcap150": "https://nsearchives.nseindia.com/content/indices/ind_niftymidcap150list.csv",
+        "Nifty Midcap 150": "https://nsearchives.nseindia.com/content/indices/ind_niftymidcap150list.csv",
         "Nifty Midcap 50": "https://nsearchives.nseindia.com/content/indices/ind_niftymidcap50list.csv",
         "Nifty Midcap Select": "https://nsearchives.nseindia.com/content/indices/ind_niftymidcapselect_list.csv",
         "Nifty Midcap 100": "https://nsearchives.nseindia.com/content/indices/ind_niftymidcap100list.csv",
@@ -79,7 +79,7 @@ class NiftyBroadMarketIndices:
         "Nifty 200": "https://nsearchives.nseindia.com/content/indices/ind_nifty_200.pdf",
         "Nifty Total Market": "https://nsearchives.nseindia.com/content/indices/Factsheet_NiftyTotalMarket.pdf",
         "Nifty 500": "https://nsearchives.nseindia.com/content/indices/ind_nifty_500.pdf",
-        "Nifty Midcap150": "https://nsearchives.nseindia.com/content/indices/ind_Nifty_Midcap_150.pdf",
+        "Nifty Midcap 150": "https://nsearchives.nseindia.com/content/indices/ind_Nifty_Midcap_150.pdf",
         "Nifty Midcap 50": "https://nsearchives.nseindia.com/content/indices/ind_nifty_midcap50.pdf",
         "Nifty Midcap Select": "https://nsearchives.nseindia.com/content/indices/Factsheet_NiftyMidcapSelect.pdf",
         "Nifty Midcap 100": "https://nsearchives.nseindia.com/content/indices/ind_niftymidcap100.pdf",

--- a/tests/test_indices_config.py
+++ b/tests/test_indices_config.py
@@ -1,0 +1,22 @@
+import unittest
+
+from nselib import indices
+from nselib.indices import nse_config
+
+
+class TestIndicesConfig(unittest.TestCase):
+    def test_broad_market_index_list_uses_nse_midcap_150_name(self):
+        broad_market_indices = indices.index_list("BroadMarketIndices")
+
+        self.assertIn("Nifty Midcap 150", broad_market_indices)
+        self.assertNotIn("Nifty Midcap150", broad_market_indices)
+
+    def test_midcap_150_config_urls_match_public_index_name(self):
+        broad_market_config = nse_config.NiftyBroadMarketIndices
+
+        self.assertIn("Nifty Midcap 150", broad_market_config.index_constituent_list_urls)
+        self.assertIn("Nifty Midcap 150", broad_market_config.index_factsheet_urls)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
broadmarket index list now matches nse's spacing, and the related constituent and factsheet maps use the same key. this keeps index_list() output working with capital_market.index_data().


Fixes #105