### PR TITLE
Handle NSE index history without HI_TIMESTAMP

### DIFF
--- a/nselib/capital_market/get_func.py
+++ b/nselib/capital_market/get_func.py
@@ -190,7 +190,7 @@ def get_index_data(index: str, from_date: str, to_date: str) -> pd.DataFrame:
         logger.error(f"Failed to fetch data: {e}", exc_info=e)
         raise NSEdataNotFound(f" Resource not available MSG: {e}")
     if not data_df.empty:
-        data_df.drop(columns="HI_TIMESTAMP", inplace=True)
+        data_df.drop(columns="HI_TIMESTAMP", inplace=True, errors="ignore")
         data_df.columns = index_data_columns
     return data_df
 

--- a/tests/test_capital_market_get_func.py
+++ b/tests/test_capital_market_get_func.py
@@ -1,0 +1,58 @@
+import unittest
+from unittest.mock import Mock, patch
+
+from nselib.capital_market.get_func import get_index_data
+from nselib.constants import index_data_columns
+
+
+class TestGetIndexData(unittest.TestCase):
+    def test_get_index_data_drops_hi_timestamp_when_present(self):
+        response = Mock()
+        response.json.return_value = {
+            "data": [
+                {
+                    "CH_INDEX_NAME": "NIFTY 50",
+                    "OPEN": 25000.0,
+                    "HIGH": 25100.0,
+                    "CLOSE": 25075.0,
+                    "LOW": 24950.0,
+                    "TURNOVER": 12345.0,
+                    "VOLUME": 67890,
+                    "TIMESTAMP": "06-May-2026",
+                    "HI_TIMESTAMP": "2026-05-06T00:00:00",
+                }
+            ]
+        }
+
+        with patch("nselib.capital_market.get_func.nse_urlfetch", return_value=response):
+            data_df = get_index_data("NIFTY 50", "30-04-2026", "06-05-2026")
+
+        self.assertEqual(list(data_df.columns), index_data_columns)
+        self.assertNotIn("HI_TIMESTAMP", data_df.columns)
+
+    def test_get_index_data_accepts_response_without_hi_timestamp(self):
+        response = Mock()
+        response.json.return_value = {
+            "data": [
+                {
+                    "CH_INDEX_NAME": "NIFTY 50",
+                    "OPEN": 25000.0,
+                    "HIGH": 25100.0,
+                    "CLOSE": 25075.0,
+                    "LOW": 24950.0,
+                    "TURNOVER": 12345.0,
+                    "VOLUME": 67890,
+                    "TIMESTAMP": "06-May-2026",
+                }
+            ]
+        }
+
+        with patch("nselib.capital_market.get_func.nse_urlfetch", return_value=response):
+            data_df = get_index_data("NIFTY 50", "30-04-2026", "06-05-2026")
+
+        self.assertEqual(list(data_df.columns), index_data_columns)
+        self.assertEqual(data_df.loc[0, "INDEX_NAME"], "NIFTY 50")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
NSE sometimes leaves HI_TIMESTAMP out of the 1W index-history response. Keep the dataframe normalization tolerant of that shape and cover both variants in tests.

Fixes RuchiTanmay/nselib#103