### PR TITLE
feat(capital_market): expose fii_dii_trading_activity and format imports

### DIFF
--- a/nselib/capital_market/__init__.py
+++ b/nselib/capital_market/__init__.py
@@ -1,8 +1,42 @@
-from .capital_market_data import price_volume_and_deliverable_position_data, price_volume_data, \
-    deliverable_position_data, bulk_deal_data, block_deals_data, short_selling_data, \
-    bhav_copy_with_delivery, bhav_copy_equities, equity_list, fno_equity_list, fno_index_list, nifty50_equity_list, \
-    niftynext50_equity_list, niftymidcap150_equity_list, niftysmallcap250_equity_list, india_vix_data, \
-    index_data, market_watch_all_indices, daily_volatility, var_begin_day, var_1st_intra_day, var_2nd_intra_day, var_3rd_intra_day, \
-    var_4th_intra_day, var_end_of_day, sme_bhav_copy, sme_band_complete, week_52_high_low_report, financial_results_for_equity, \
-    corporate_bond_trade_report, bhav_copy_sme, pe_ratio, corporate_actions_for_equity, event_calendar_for_equity, \
-    top_gainers_or_losers, most_active_equities, total_traded_stocks, category_turnover_cash, business_growth_cm_segment
+from .capital_market_data import (
+    price_volume_and_deliverable_position_data,
+    price_volume_data,
+    deliverable_position_data,
+    bulk_deal_data,
+    block_deals_data,
+    short_selling_data,
+    bhav_copy_with_delivery,
+    bhav_copy_equities,
+    equity_list,
+    fno_equity_list,
+    fno_index_list,
+    nifty50_equity_list,
+    niftynext50_equity_list,
+    niftymidcap150_equity_list,
+    niftysmallcap250_equity_list,
+    india_vix_data,
+    index_data,
+    market_watch_all_indices,
+    daily_volatility,
+    var_begin_day,
+    var_1st_intra_day,
+    var_2nd_intra_day,
+    var_3rd_intra_day,
+    var_4th_intra_day,
+    var_end_of_day,
+    sme_bhav_copy,
+    sme_band_complete,
+    week_52_high_low_report,
+    financial_results_for_equity,
+    corporate_bond_trade_report,
+    bhav_copy_sme,
+    pe_ratio,
+    corporate_actions_for_equity,
+    event_calendar_for_equity,
+    top_gainers_or_losers,
+    most_active_equities,
+    total_traded_stocks,
+    category_turnover_cash,
+    business_growth_cm_segment,
+    fii_dii_trading_activity,
+)


### PR DESCRIPTION
#### feat(capital_market): expose fii_dii_trading_activity and format imports
- Exposes the missing `fii_dii_trading_activity` function in the `capital_market`.
- Reformats imports in `nselib/capital_market/__init__.py` to use parenthesized multi-line syntax for improved readability and PEP 8 compliance.

Fixes #124
Ref: https://github.com/RuchiTanmay/nselib/issues/124